### PR TITLE
Add support for testing against Heimdal realms

### DIFF
--- a/k5test/realm.py
+++ b/k5test/realm.py
@@ -103,7 +103,14 @@ class K5Realm(object):
                 krb5_version = krb5_version.decode(
                     sys.getfilesystemencoding() or sys.getdefaultencoding())
 
-                if 'heimdal' in krb5_version.lower():
+                if (
+                    'heimdal' in krb5_version.lower() or
+                    (
+                        # macOS output doesn't contain Heimdal
+                        os.name == 'darwin' and
+                        krb5_config == '/usr/bin/krb5-config'
+                    )
+                ):
                     provider_cls = HeimdalRealm
 
                 else:


### PR DESCRIPTION
This adds support for using `k5test` against a Heimdal install. It extracts provider specific logic into their own classes and implements the basic methods for Heimdal. The realm type is chosen based on the value of `krb5-config --version`.