### PR TITLE
Fix typos in default krb paths

### DIFF
--- a/k5test/realm.py
+++ b/k5test/realm.py
@@ -435,8 +435,8 @@ class MITRealm(K5Realm):
     def _default_paths(self):
         return [
             ('kdb5_util', 'kdb5_util', '/usr/sbin/kdb5_util'),
-            ('krb5kdc', 'krb5kdc', '/usr/sbin/kdb5kdc'),
-            ('kadmin', 'kadmin', '/usr/bin/admin'),
+            ('krb5kdc', 'krb5kdc', '/usr/sbin/krb5kdc'),
+            ('kadmin', 'kadmin', '/usr/bin/kadmin'),
             ('kadmin_local', 'kadmin.local', '/usr/sbin/kadmin.local'),
             ('kadmind', 'kadmind', '/usr/sbin/kadmind'),
             ('kprop', 'kprop', '/usr/sbin/kprop'),


### PR DESCRIPTION
Fixes: https://github.com/pythongssapi/k5test/issues/15