### PR TITLE
Add basic sanity checks and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,83 @@
+name: Test k5test
+on:
+  push:
+    branches:
+    - main
+    paths-ignore:
+    - CODE_OF_CONDUCT.md
+    - K5TEST-LICENSE.txt
+    - LICENSE.txt
+    - README.md
+
+  pull_request:
+    branches:
+    - main
+    paths-ignore:
+    - CODE_OF_CONDUCT.md
+    - K5TEST-LICENSE.txt
+    - LICENSE.txt
+    - README.md
+
+  release:
+    types:
+    - published
+
+  schedule:
+  - cron: 0 9 * * *
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v2
+
+    - name: Test
+      run: |
+        echo "::group::Installing Python Requirements"
+
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --requirement requirements-dev.txt
+        python -m pip install .
+
+        echo "::endgroup::"
+
+        echo "::group::Running Sanity Checks"
+
+        python -m black . --check
+        python -m isort . --check-only
+
+        echo "::endgroup::"
+
+  publish:
+    name: publish
+    needs:
+    - test
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v2
+
+    - name: Build sdist and wheel
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python setup.py bdist_wheel --universal
+        python setup.py sdist
+
+    - name: Capture sdist and wheel
+      uses: actions/upload-artifact@v2
+      with:
+        name: k5test
+        path: dist/*
+
+    - name: Publish
+      if: startsWith(github.ref, 'refs/tags/v')
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+- repo: https://github.com/psf/black
+  rev: 21.9b0
+  hooks:
+  - id: black
+
+- repo: https://github.com/PyCQA/isort
+  rev: 5.9.3
+  hooks:
+  - id: isort

--- a/k5test/_utils.py
+++ b/k5test/_utils.py
@@ -1,12 +1,12 @@
 import os
-import sys
 import subprocess
+import sys
 
 
 # general use
 def get_output(*args, **kwargs):
     res = subprocess.check_output(*args, shell=True, **kwargs)
-    decoded = res.decode('utf-8')
+    decoded = res.decode("utf-8")
     return decoded.strip()
 
 
@@ -27,7 +27,7 @@ def import_gssapi_extension(name):
     """
 
     try:
-        path = 'gssapi.raw.ext_{0}'.format(name)
+        path = "gssapi.raw.ext_{0}".format(name)
         __import__(path)
         return sys.modules[path]
     except ImportError:
@@ -44,33 +44,31 @@ def find_plugin_dir():
         return _PLUGIN_DIR
 
     # if we've set a LD_LIBRARY_PATH, use that first
-    ld_path_raw = os.environ.get('LD_LIBRARY_PATH')
+    ld_path_raw = os.environ.get("LD_LIBRARY_PATH")
     if ld_path_raw is not None:
         # first, try assuming it's just a normal install
 
-        ld_paths = [path for path in ld_path_raw.split(':') if path]
+        ld_paths = [path for path in ld_path_raw.split(":") if path]
 
         for ld_path in ld_paths:
             if not os.path.exists(ld_path):
                 continue
 
-            _PLUGIN_DIR = _decide_plugin_dir(
-                _find_plugin_dirs_installed(ld_path))
+            _PLUGIN_DIR = _decide_plugin_dir(_find_plugin_dirs_installed(ld_path))
             if _PLUGIN_DIR is None:
-                _PLUGIN_DIR = _decide_plugin_dir(
-                    _find_plugin_dirs_src(ld_path))
+                _PLUGIN_DIR = _decide_plugin_dir(_find_plugin_dirs_src(ld_path))
 
             if _PLUGIN_DIR is not None:
                 break
 
     # if there was no LD_LIBRARY_PATH, or the above failed
     if _PLUGIN_DIR is None:
-        lib_dir = os.path.join(get_output('krb5-config --prefix'), 'lib64')
+        lib_dir = os.path.join(get_output("krb5-config --prefix"), "lib64")
         _PLUGIN_DIR = _decide_plugin_dir(_find_plugin_dirs_installed(lib_dir))
 
     # /usr/lib64 seems only to be distinct on Fedora/RHEL/Centos family
     if _PLUGIN_DIR is None:
-        lib_dir = os.path.join(get_output('krb5-config --prefix'), 'lib')
+        lib_dir = os.path.join(get_output("krb5-config --prefix"), "lib")
         _PLUGIN_DIR = _decide_plugin_dir(_find_plugin_dirs_installed(lib_dir))
 
     if _PLUGIN_DIR is not None:
@@ -97,23 +95,25 @@ def _decide_plugin_dir(dirs):
 
 def _find_plugin_dirs_installed(search_path):
     try:
-        options_raw = get_output('find %s/ -type d \( ! -executable -o ! -readable \) '
-                                 '-prune -o '
-                                 '-type d -path "*/krb5/plugins" -print' % search_path,
-                                 stderr=subprocess.STDOUT)
+        options_raw = get_output(
+            "find %s/ -type d \( ! -executable -o ! -readable \) "
+            "-prune -o "
+            '-type d -path "*/krb5/plugins" -print' % search_path,
+            stderr=subprocess.STDOUT,
+        )
     except subprocess.CalledProcessError:
         options_raw = None
 
     if options_raw:
-        return options_raw.split('\n')
+        return options_raw.split("\n")
     else:
         return None
 
 
 def _find_plugin_dirs_src(search_path):
-    options_raw = get_output('find %s/../ -type d -name plugins' % search_path)
+    options_raw = get_output("find %s/../ -type d -name plugins" % search_path)
 
     if options_raw:
-        return options_raw.split('\n')
+        return options_raw.split("\n")
     else:
         return None

--- a/k5test/unit.py
+++ b/k5test/unit.py
@@ -1,8 +1,7 @@
-import unittest
 import os
+import unittest
 
-from k5test import realm
-from k5test import _utils
+from k5test import _utils, realm
 
 
 # test case class
@@ -22,8 +21,10 @@ def gssapi_extension_test(extension_name, extension_text):
     def make_ext_test(func):
         def ext_test(self, *args, **kwargs):
             if _utils.import_gssapi_extension(extension_name) is None:
-                self.skipTest("The %s GSSAPI extension is not supported by "
-                              "your GSSAPI implementation" % extension_text)
+                self.skipTest(
+                    "The %s GSSAPI extension is not supported by "
+                    "your GSSAPI implementation" % extension_text
+                )
             else:
                 func(self, *args, **kwargs)
 
@@ -39,16 +40,20 @@ def krb_minversion_test(target_version, problem, provider=None):
     global _KRB_VERSION
     if _KRB_VERSION is None:
         _KRB_VERSION = _utils.get_output("krb5-config --version")
-        _KRB_VERSION = _KRB_VERSION.split(' ')[-1].split('.')
+        _KRB_VERSION = _KRB_VERSION.split(" ")[-1].split(".")
 
     def make_ext_test(func):
         def ext_test(self, *args, **kwargs):
-            if _KRB_VERSION < target_version.split('.') and (
-                    not provider or self.realm.lower() == provider.lower()):
-                self.skipTest("Your GSSAPI (version %s) is known to have "
-                              "problems with %s" % (_KRB_VERSION, problem))
+            if _KRB_VERSION < target_version.split(".") and (
+                not provider or self.realm.lower() == provider.lower()
+            ):
+                self.skipTest(
+                    "Your GSSAPI (version %s) is known to have "
+                    "problems with %s" % (_KRB_VERSION, problem)
+                )
             else:
                 func(self, *args, **kwargs)
+
         return ext_test
 
     return make_ext_test
@@ -60,15 +65,15 @@ def krb_plugin_test(plugin_type, plugin_name):
     krb5_plugin_path = _utils.find_plugin_dir()
     plugin_path = None
     if krb5_plugin_path:
-        plugin_path = os.path.join(krb5_plugin_path, plugin_type,
-                                   f"{plugin_name}.so")
+        plugin_path = os.path.join(krb5_plugin_path, plugin_type, f"{plugin_name}.so")
 
     def make_krb_plugin_test(func):
         def krb_plugin_test(self, *args, **kwargs):
             if not plugin_path or not os.path.exists(plugin_path):
-                self.skipTest("You do not have the GSSAPI {type}"
-                              "plugin {name} installed".format(
-                                  type=plugin_type, name=plugin_name))
+                self.skipTest(
+                    "You do not have the GSSAPI {type}"
+                    "plugin {name} installed".format(type=plugin_type, name=plugin_name)
+                )
             else:
                 func(self, *args, **kwargs)
 
@@ -82,8 +87,10 @@ def krb_provider_test(providers, problem):
         def krb_provider_test(self, *args, **kwargs):
             provider_list = [p.lower() for p in providers]
             if self.realm.provider.lower() not in provider_list:
-                self.skipTest(f"Your GSSAPI (provider {self.realm.provider}) "
-                              f"is known to have problems with {problem}")
+                self.skipTest(
+                    f"Your GSSAPI (provider {self.realm.provider}) "
+                    f"is known to have problems with {problem}"
+                )
             else:
                 func(self, *args, **kwargs)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = ["setuptools >= 40.6.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.isort]
+profile = "black"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+black
+isort
+pre-commit

--- a/setup.py
+++ b/setup.py
@@ -1,36 +1,34 @@
 #!/usr/bin/env python
 from setuptools import setup
 
-
 setup(
-    name='k5test',
-    version='0.10.0',
-    author='The Python GSSAPI Team',
-    author_email='sross@redhat.com',
-    packages=['k5test'],
-    description='A library for testing Python applications in '
-                'self-contained Kerberos 5 environments',
-    long_description=open('README.md').read(),
-    license='LICENSE.txt',
+    name="k5test",
+    version="0.10.1",
+    author="The Python GSSAPI Team",
+    author_email="sross@redhat.com",
+    packages=["k5test"],
+    description="A library for testing Python applications in "
+    "self-contained Kerberos 5 environments",
+    long_description=open("README.md").read(),
+    license="LICENSE.txt",
     url="https://github.com/pythongssapi/k5test",
     python_requires=">=3.6",
     classifiers=[
-        'Development Status :: 4 - Beta',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: ISC License (ISCL)',
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Topic :: Security',
+        "Development Status :: 4 - Beta",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: ISC License (ISCL)",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Topic :: Security",
     ],
-    keywords=['gssapi', 'security'],
+    keywords=["gssapi", "security"],
     install_requires=[],
-    extras_require={
-        'extension_test': ['gssapi']
-    }
+    extras_require={"extension_test": ["gssapi"]},
 )


### PR DESCRIPTION
This adds `black` and `isort` as very basic sanity checks and reformats them to pass the default configuration. Also adds a CI run to run these sanity checks and add an automated publishing step.

Signed-off-by: Jordan Borean <jborean93@gmail.com>