### PR TITLE
Include both license files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,10 @@ setup(
     description="A library for testing Python applications in "
     "self-contained Kerberos 5 environments",
     long_description=open("README.md").read(),
-    license="LICENSE.txt",
+    license_files=[
+        "LICENSE.txt",
+        "K5TEST-LICENSE.txt",
+    ],
     url="https://github.com/pythongssapi/k5test",
     python_requires=">=3.6",
     classifiers=[


### PR DESCRIPTION
The license keyword is meant for specifying the license string, not the file name of the license.  The correct keyword to use for this is license_files.  Currently the LICENSE.txt file is being included because license_files defaults to "LICEN[CS]E*", but K5TEST-LICENSE.txt is missing.  This change switches to the correct keyword, and additionally includes the K5TEST-LICENSE.txt file.