### PR TITLE
Set max_renewable_life to 1 week for the MIT KDC

### DIFF
--- a/k5test/realm.py
+++ b/k5test/realm.py
@@ -499,6 +499,7 @@ class MITRealm(K5Realm):
                     "kdc_ports": "$port0",
                     "kdc_tcp_ports": "$port0",
                     "database_name": "$tmpdir/db",
+                    "max_renewable_life": "7d",
                 }
             },
             "dbmodules": {


### PR DESCRIPTION
Currently there is no `max_renewable_life` setting for the MIT KDC, which the MIT KDC interprets as 0 seconds. This will cause problems when testing ticket renewal.

This causes the tests with https://github.com/jborean93/pykrb5/pull/40 to fail sometimes with the error message <https://github.com/steffen-kiess/pykrb5/actions/runs/8299662077/job/22716417142>:
```
  FAILED tests/test_creds.py::test_renew_creds - krb5._exceptions.Krb5Error: Ticket expired -1765328352
```
The reason that it fails only sometimes is that when the renewal attempt happens in the same second when the ticket was generated, the renewal succeeds.