### PR TITLE
use krb5-config to get the kerberos installation PREFIX

### DIFF
--- a/k5test/_utils.py
+++ b/k5test/_utils.py
@@ -96,7 +96,7 @@ def _decide_plugin_dir(dirs):
 def _find_plugin_dirs_installed(search_path):
     try:
         options_raw = get_output(
-            "find %s/ -type d \( ! -executable -o ! -readable \) "
+            "find %s/ -type d \\( ! -executable -o ! -readable \\) "
             "-prune -o "
             '-type d -path "*/krb5/plugins" -print' % search_path,
             stderr=subprocess.STDOUT,


### PR DESCRIPTION
This fixes tests on FreeBSD where the installation could either be at `/usr/` (for base system kerberos) or `/usr/local` (for ports-provided kerberos).

Also fix bad escape sequence warning.